### PR TITLE
Mar-3977 -  adding validation message for dates in the past within Specialist Brief

### DIFF
--- a/ui-automated-tests/src/flows/brief/specialist.ts
+++ b/ui-automated-tests/src/flows/brief/specialist.ts
@@ -131,7 +131,6 @@ const fillSellerResponses = async (): Promise<{ numberOfSuppliers: string }> => 
 const fillTimeframes = async () => {
   await clickSaveContinue();
   await utils.matchText("li", "Enter an estimated start date for the opportunity");
-  await utils.matchText("li", "You must enter a valid start date");
   await utils.matchText("li", "Enter a contract length for the opportunity");
   const now = new Date();
   const future = new Date(now.setDate(now.getDate() + 14));


### PR DESCRIPTION
This PR will update ui tests. 

When the form is empty, instead of getting 2 messages that says 'you must enter a valid start date' and 'Enter an estimated start date for the opportunity', it will only show 'Enter an estimated start date'

This wasn't included as part of the ticket but I did it anyway since it didn't make much sense.